### PR TITLE
5 feature クリックによる読み上げトリガー

### DIFF
--- a/auticle/background.js
+++ b/auticle/background.js
@@ -1,3 +1,22 @@
 chrome.runtime.onInstalled.addListener(() => {
   console.log("Auticle extension installed.");
 });
+
+chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+  if (changeInfo.status === "complete" && !tab.url.startsWith("chrome://")) {
+    // Inject content script
+    await chrome.scripting.executeScript({
+      target: { tabId: tabId },
+      files: ["content.js"],
+    });
+
+    // Send current state
+    chrome.storage.local.get(["enabled"], (result) => {
+      const enabled = result.enabled || false;
+      chrome.tabs.sendMessage(tabId, {
+        command: "stateChange",
+        enabled: enabled,
+      });
+    });
+  }
+});

--- a/auticle/content.js
+++ b/auticle/content.js
@@ -25,7 +25,8 @@ function preparePage() {
   }
 
   // Select paragraph elements in article or main
-  const paragraphs = document.querySelectorAll("article p, main p");
+  const selectors = "article p, main p, .post-body p";
+  const paragraphs = document.querySelectorAll(selectors);
   paragraphs.forEach((element, index) => {
     element.dataset.auticleId = index;
     element.classList.add("auticle-clickable");
@@ -33,6 +34,9 @@ function preparePage() {
 
   // Inject styles
   injectStyles();
+
+  // Add click event listener for triggering playback
+  document.addEventListener("click", handleClick);
 }
 
 function cleanupPage() {
@@ -45,6 +49,22 @@ function cleanupPage() {
 
   // Remove injected styles
   removeStyles();
+
+  // Remove click event listener
+  document.removeEventListener("click", handleClick);
+}
+
+function handleClick(event) {
+  const target = event.target.closest(".auticle-clickable");
+  if (target) {
+    const id = parseInt(target.dataset.auticleId);
+    const paragraphs = document.querySelectorAll(".auticle-clickable");
+    let text = "";
+    for (let i = id; i < paragraphs.length; i++) {
+      text += paragraphs[i].textContent + "\n\n";
+    }
+    chrome.runtime.sendMessage({ command: "play", text: text });
+  }
 }
 
 function injectStyles() {


### PR DESCRIPTION
### Issue #5: クリックによる読み上げトリガーのまとめ
- **実装内容**:
  - content.js: `preparePage()` でイベント委任（`document.addEventListener('click', handleClick)`）を追加。`handleClick()` でクリックされた段落のIDを取得、以後のテキストを収集・結合、background.js に `{ command: 'play', text: text }` メッセージ送信。`cleanupPage()` でリスナー削除。
  - background.js: `chrome.tabs.onUpdated` リスナー追加。タブ読み込み完了時に content.js を注入し、ストレージから `enabled` を取得してメッセージ送信（ポップアップ不要で自動初期化）。

- **目的**: スイッチON時に段落クリックで読み上げテキストを収集し、バックグラウンドに送信。ページ読み込み時に自動で状態反映。

### 最後の初期化アップデート
- background.js に `chrome.tabs.onUpdated` を追加: タブ読み込み完了時（`changeInfo.status === 'complete'`）に content.js を注入し、現在の `enabled` 状態をメッセージ送信。これにより、ポップアップを出さなくてもハイライトが自動適用。

### テスト方法
1. Chrome拡張機能をリロード。
2. 記事ページを開く（ポップアップを出さずに） → トグルONならハイライト自動表示。
3. 段落をクリック → Consoleでエラーがないか確認（background.js に `play` リスナーがない場合、送信エラー表示）。
4. ポップアップを開いてトグル変更 → 即座に反映。

